### PR TITLE
Define _DEFAULT_SOURCE for using usleep

### DIFF
--- a/lib/src/Makefile
+++ b/lib/src/Makefile
@@ -3,6 +3,8 @@ L4DIR  ?= $(PKGDIR)/../..
 
 DEFINES-$(CONFIG_IXL_NDEBUG) += -DIXL_NDEBUG
 
+DEFINES += -D_DEFAULT_SOURCE
+
 REQUIRES_LIBS = libpthread libio-vbus libc_support_misc libstdc++
 # If chosen by the user, add jemalloc to the end of the libraries, catching all
 # memory allocation calls.


### PR DESCRIPTION
usleep requires _DEFAULT_SOURCE to be defined, thus define it.